### PR TITLE
update package.json dependencies to use npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "alias",
   "version": "0.2.0",
   "dependencies": {
-    "clone": "component/clone",
-    "type": "component/type"
+    "component-clone": "^0.2.2",
+    "component-type": "^1.2.1"
   }
 }


### PR DESCRIPTION
@jgershen this uses npm equivalents so that if we decide to use this repo as npm it actually won't throw more module errors lol